### PR TITLE
fix: removed inline style

### DIFF
--- a/erpnext/public/scss/website.scss
+++ b/erpnext/public/scss/website.scss
@@ -78,3 +78,7 @@
 		z-index: 0;
 	}
 }
+
+.place-order-container {
+	text-align: right;
+}

--- a/erpnext/templates/pages/cart.html
+++ b/erpnext/templates/pages/cart.html
@@ -50,9 +50,11 @@
 	<p class="text-muted">{{ _('Your cart is Empty') }}</p>
 	{% endif %}
 	{% if doc.items and cart_settings.enable_checkout %}
-		<button class="btn btn-primary btn-place-order" type="button" style="float:right">
+	<div class="place-order-container">
+		<button class="btn btn-primary btn-place-order" type="button">
 			{{ _("Place Order") }}
 		</button>
+	</div>
 	{% endif %}
 
 	{% if doc.items %}


### PR DESCRIPTION
**Task:** To remove inline styling

**Screenshot**:
![Screenshot 2020-03-17 at 5 00 01 PM](https://user-images.githubusercontent.com/49683121/76852180-ca6d2d80-6870-11ea-8806-07bba7feae3a.png)

**Note**:
Style appearing in the screenshot is different due to the JHAudio app I'm using. It won't affect actual style of Frappe/ErpNext.